### PR TITLE
0.9.1.x updates: Add half-space orientation predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bisect3w: orientation of point wrt. half-space in E^3 (weighted).
 inball3d: point-in-circumball (Delaunay-Voronoi tessellations) in E^3.
 inball3w: point-in-ortho-ball (Regular-Laguerre tessellations) in E^3.
 ````
-A simplified two-stage variation on <a href=https://doi.org/10.1007/PL00009321>Shewchuk's original arithmetic</a> is employed, adopting standard (fast!) floating-point approximations when results are unambiguous and falling back onto (slower) arbitrary precision evaluations as necessary to guarantee "sign-correctness". Semi-static filters are used to toggle between floating-point and arbitrary precision implementations.
+A simplified two-stage variation on <a href=https://doi.org/10.1007/PL00009321>Shewchuk's original arithmetic</a> is employed, adopting standard (fast!) floating-point approximations when results are unambiguous and falling back onto (slower) arbitrary precision evaluations as necessary to guarantee "sign-correctness". Semi-static filters are used to toggle between floating-point and arbitrary precision kernels.
 
 ### `License`
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,18 @@ This package aims to implement a "zero-overhead" abstraction; leveraging various
 The following predicates are currently available:
 ````
 orient2d: orientation of 3 points in E^2, or a point wrt. a line.
+bisect2d: orientation of point wrt. half-space in E^2.
+bisect2w: orientation of point wrt. half-space in E^2 (weighted).
 inball2d: point-in-circumball (Delaunay-Voronoi tessellations) in E^2. 
-inball2w: point-in-ortho-ball (Laguerre-Regular tessellations) in E^2.
+inball2w: point-in-ortho-ball (Regular-Laguerre tessellations) in E^2.
 
 orient3d: orientation of 4 points in E^3, or a point wrt. a plane.
+bisect3d: orientation of point wrt. half-space in E^3.
+bisect3w: orientation of point wrt. half-space in E^3 (weighted).
 inball3d: point-in-circumball (Delaunay-Voronoi tessellations) in E^3.
-inball3w: point-in-ortho-ball (Laguerre-Regular tessellations) in E^3.
+inball3w: point-in-ortho-ball (Regular-Laguerre tessellations) in E^3.
 ````
-A simplified two-stage variation on <a href=https://doi.org/10.1007/PL00009321>Shewchuk's original arithmetic</a> is employed, adopting standard floating-point approximations when results are unambiguous and falling back onto (slower) arbitrary precision evaluations as necessary to guarantee "sign-correctness". 
+A simplified two-stage variation on <a href=https://doi.org/10.1007/PL00009321>Shewchuk's original arithmetic</a> is employed, adopting standard (fast!) floating-point approximations when results are unambiguous and falling back onto (slower) arbitrary precision evaluations as necessary to guarantee "sign-correctness". Semi-static filters are used to toggle between floating-point and arbitrary precision implementations.
 
 ### `License`
 
@@ -29,3 +33,6 @@ This program may be freely redistributed under the condition that the copyright 
 `[1]` - J. R. Shewchuk (1997), Adaptive Precision Floating-Point Arithmetic & Fast Robust Geometric Predicates. Discrete & Computational Geometry, 18, pp. 305-363.
 
 `[2]` - B. Lévy (2016), Robustness and efficiency of geometric programs: The Predicate Construction Kit (PCK). Computer-Aided Design, 72, pp. 03-12.
+
+`[3]` - C. Burnikel, S. Funke, and M. Seel (2001), Exact geometric computation using cascading. IJCGA (Special issue) 11 (3), pp. 245–266.
+

--- a/example.cpp
+++ b/example.cpp
@@ -38,7 +38,33 @@ int main () {
         _pa, _pb, _qq
         ) ;
 
+    std::cout << std::showpos;
+
     std::cout << "orient2d: " << _rr;
+    std::cout << std::endl;
+
+    // Test the orienation of the point QQ wrt. the half-
+    // space of PA, PB. 
+
+    // This is the unweighted case in E^2.
+
+    _rr = geompred::bisect2d (
+        _pa, _pb, _qq
+        ) ;
+
+    std::cout << "bisect2d: " << _rr;
+    std::cout << std::endl;
+
+    // Test the orienation of the point QQ wrt. the half-
+    // space of PA, PB. 
+
+    // This is the "weighted" case in E^2.
+
+    _rr = geompred::bisect2w (
+        _pa, _pb, _qq
+        ) ;
+
+    std::cout << "bisect2w: " << _rr;
     std::cout << std::endl;
 
     // Test whether the point QQ is contained within the
@@ -96,6 +122,30 @@ int main () {
         ) ;
 
     std::cout << "orient3d: " << _rr;
+    std::cout << std::endl;
+
+    // Test the orienation of the point QQ wrt. the half-
+    // space of PA, PB. 
+
+    // This is the unweighted case in E^3.
+
+    _rr = geompred::bisect3d (
+        _PA, _PB, _QQ
+        ) ;
+
+    std::cout << "bisect3d: " << _rr;
+    std::cout << std::endl;
+
+    // Test the orienation of the point QQ wrt. the half-
+    // space of PA, PB. 
+
+    // This is the "weighted" case in E^3.
+
+    _rr = geompred::bisect3w (
+        _PA, _PB, _QQ
+        ) ;
+
+    std::cout << "bisect3w: " << _rr;
     std::cout << std::endl;
 
     // Test whether the point QQ is contained within the

--- a/expansion/mp_float.hpp
+++ b/expansion/mp_float.hpp
@@ -55,7 +55,7 @@
      *
     --------------------------------------------------------
      *
-     * Last updated: 03 March, 2020
+     * Last updated: 07 April, 2020
      *
      * Copyright 2020--
      * Darren Engwirda
@@ -655,7 +655,7 @@
         size_t NA, size_t NB, size_t NC,
         size_t ND
              >
-    __normal_call void      expansion_add (
+    __inline_call void      expansion_add (
         expansion <NA> const& _aa,
         expansion <NB> const& _bb,
         expansion <NC> const& _cc,
@@ -672,7 +672,7 @@
         size_t NA, size_t NB, size_t NC,
         size_t ND, size_t NE
              >
-    __normal_call void      expansion_add (
+    __inline_call void      expansion_add (
         expansion <NA> const& _aa,
         expansion <NB> const& _bb,
         expansion <NC> const& _cc,
@@ -921,6 +921,61 @@
 
         return    _rr ;
     }
+
+    /*
+    --------------------------------------------------------
+     * form dot-products for multi-precision expansions
+    --------------------------------------------------------
+     */
+
+    template <
+        size_t AX, size_t BX, size_t AY,
+        size_t BY, size_t NP
+             >
+    __inline_call void      expansion_dot (
+        expansion <AX> const& _xa,
+        expansion <BX> const& _xb,
+        expansion <AY> const& _ya,
+        expansion <BY> const& _yb,
+        expansion <NP> & _dp
+        )                           // 2-dim dotproduct
+    {
+        expansion<mul_alloc(AX,  BX)> _xp ;
+        expansion_mul(_xa, _xb, _xp);
+
+        expansion<mul_alloc(AY,  BY)> _yp ;
+        expansion_mul(_ya, _yb, _yp);
+
+        expansion_add(_xp, _yp, _dp);
+    }
+
+    template <
+        size_t AX, size_t BX, size_t AY,
+        size_t BY, size_t AZ, size_t BZ,
+        size_t NP
+             >
+    __inline_call void      expansion_dot (
+        expansion <AX> const& _xa,
+        expansion <BX> const& _xb,
+        expansion <AY> const& _ya,
+        expansion <BY> const& _yb,
+        expansion <AZ> const& _za,
+        expansion <BZ> const& _zb,
+        expansion <NP> & _dp
+        )                           // 3-dim dotproduct
+    {
+        expansion<mul_alloc(AX,  BX)> _xp ;
+        expansion_mul(_xa, _xb, _xp);
+
+        expansion<mul_alloc(AY,  BY)> _yp ;
+        expansion_mul(_ya, _yb, _yp);
+
+        expansion<mul_alloc(AZ,  BZ)> _zp ;
+        expansion_mul(_za, _zb, _zp);
+
+        expansion_add(_xp, _yp, _zp,  _dp);
+    }
+
 
 #   undef REAL_TYPE
 #   undef INDX_TYPE

--- a/predicate/bisect_k.hpp
+++ b/predicate/bisect_k.hpp
@@ -1,0 +1,452 @@
+
+    /*
+    --------------------------------------------------------
+     * PREDICATE-k: robust geometric predicates in E^k.
+    --------------------------------------------------------
+     *
+     * This program may be freely redistributed under the
+     * condition that the copyright notices (including this
+     * entire header) are not removed, and no compensation
+     * is received through use of the software.  Private,
+     * research, and institutional use is free.  You may
+     * distribute modified versions of this code UNDER THE
+     * CONDITION THAT THIS CODE AND ANY MODIFICATIONS MADE
+     * TO IT IN THE SAME FILE REMAIN UNDER COPYRIGHT OF THE
+     * ORIGINAL AUTHOR, BOTH SOURCE AND OBJECT CODE ARE
+     * MADE FREELY AVAILABLE WITHOUT CHARGE, AND CLEAR
+     * NOTICE IS GIVEN OF THE MODIFICATIONS.  Distribution
+     * of this code as part of a commercial system is
+     * permissible ONLY BY DIRECT ARRANGEMENT WITH THE
+     * AUTHOR.  (If you are not directly supplying this
+     * code to a customer, and you are instead telling them
+     * how they can obtain it for free, then you are not
+     * required to make any arrangement with me.)
+     *
+     * Disclaimer:  Neither I nor: Columbia University, The
+     * Massachusetts Institute of Technology, The
+     * University of Sydney, nor The National Aeronautics
+     * and Space Administration warrant this code in any
+     * way whatsoever.  This code is provided "as-is" to be
+     * used at your own risk.
+     *
+    --------------------------------------------------------
+     *
+     * Last updated: 07 April, 2020
+     *
+     * Copyright 2020--
+     * Darren Engwirda
+     * de2363@columbia.edu
+     * https://github.com/dengwirda/
+     *
+    --------------------------------------------------------
+     */
+
+    // from predicate_k.hpp...
+
+
+    /*
+    --------------------------------------------------------
+     *
+     * Compute an exact orientation wrt. bisector using 
+     * multi-precision expansions, a'la shewchuk
+     *
+     *   |c-a|**2 - wa = |c-b|**2 - wb
+     *
+     * This is the unweighted "bisect" predicate in E^2.
+     *
+    --------------------------------------------------------
+     */
+
+    __normal_call REAL_TYPE bisect2d_e (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc ,
+        REAL_TYPE &_FT
+        )
+    {
+    /*--------------- bisect2d predicate, "exact" version */
+        mp::expansion< 2 > _ac_xx_, _ac_yy_, 
+                           _bc_xx_, _bc_yy_;
+        mp::expansion< 16> _ac_sq_, _bc_sq_;
+        mp::expansion< 32> _absum_;
+        
+        _FT = (REAL_TYPE) +0.0E+00;
+
+    /*----------------------------------- compute: d(p,q) */
+        _ac_xx_.from_sub(_pc[0], _pa[0]);
+        _ac_yy_.from_sub(_pc[1], _pa[1]);
+
+        _bc_xx_.from_sub(_pc[0], _pb[0]);
+        _bc_yy_.from_sub(_pc[1], _pb[1]);
+    
+        mp::expansion_dot(_ac_xx_, _ac_xx_,
+                          _ac_yy_, _ac_yy_,
+                          _ac_sq_) ;
+
+        mp::expansion_dot(_bc_xx_, _bc_xx_,
+                          _bc_yy_, _bc_yy_,
+                          _bc_sq_) ;
+
+    /*----------------------------------- d(a,c) - d(b,c) */
+        mp::expansion_sub(
+            _ac_sq_, _bc_sq_, _absum_) ;
+
+    /*----------------------------------- return signed d */
+        return _absum_[_absum_._xlen - 1] ;
+    }
+
+    __normal_call REAL_TYPE bisect2d_f (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc ,
+        REAL_TYPE &_FT
+        )
+    {
+    /*--------------- bisect2d predicate, "float" version */
+        REAL_TYPE static const _ER =
+        +  5. * std::pow(mp::_epsilon, 1) ;
+
+        REAL_TYPE _acx, _acy ;
+        REAL_TYPE _bcx, _bcy ;
+        REAL_TYPE _acsqr, _bcsqr ;
+
+        REAL_TYPE _ACSQR, _BCSQR ;
+
+        _acx = _pa [0] - _pc [0] ;        // coord. diff.
+        _acy = _pa [1] - _pc [1] ;
+
+        _bcx = _pb [0] - _pc [0] ;
+        _bcy = _pb [1] - _pc [1] ;
+
+        _acsqr = _acx * _acx +
+                 _acy * _acy ;
+        _bcsqr = _bcx * _bcx +
+                 _bcy * _bcy ;
+
+        _ACSQR = std::abs(_acsqr);
+        _BCSQR = std::abs(_bcsqr);
+
+        _FT  = _ACSQR + _BCSQR ;          // roundoff tol
+        _FT *= _ER ;
+
+        return _acsqr - _bcsqr ;          // d_ab - d_bc
+    }
+
+    /*
+    --------------------------------------------------------
+     *
+     * Compute an exact orientation wrt. bisector using 
+     * multi-precision expansions, a'la shewchuk
+     *
+     *   |c-a|**2 - wa = |c-b|**2 - wb
+     *
+     * This is the weighted "bisect" predicate in E^2.
+     *
+    --------------------------------------------------------
+     */
+
+    __normal_call REAL_TYPE bisect2w_e (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc ,
+        REAL_TYPE &_FT
+        )
+    {
+    /*--------------- bisect2w predicate, "exact" version */
+        mp::expansion< 2 > _ac_xx_, _ac_yy_, 
+                           _bc_xx_, _bc_yy_;
+        mp::expansion< 16> _ac_sq_, _bc_sq_;
+        mp::expansion< 17> _a_sum_, _b_sum_;
+        mp::expansion< 34> _absum_;
+        
+        _FT = (REAL_TYPE) +0.0E+00;
+
+        mp::expansion< 1 > _pa_ww_(_pa[ 2]);
+        mp::expansion< 1 > _pb_ww_(_pb[ 2]);
+
+    /*----------------------------------- compute: d(p,q) */
+        _ac_xx_.from_sub(_pc[0], _pa[0]);
+        _ac_yy_.from_sub(_pc[1], _pa[1]);
+
+        _bc_xx_.from_sub(_pc[0], _pb[0]);
+        _bc_yy_.from_sub(_pc[1], _pb[1]);
+    
+        mp::expansion_dot(_ac_xx_, _ac_xx_,
+                          _ac_yy_, _ac_yy_,
+                          _ac_sq_) ;
+
+        mp::expansion_dot(_bc_xx_, _bc_xx_,
+                          _bc_yy_, _bc_yy_,
+                          _bc_sq_) ;
+
+        mp::expansion_sub(
+            _ac_sq_, _pa_ww_, _a_sum_) ;
+
+        mp::expansion_sub(
+            _bc_sq_, _pb_ww_, _b_sum_) ;
+
+    /*----------------------------------- d(a,c) - d(b,c) */
+        mp::expansion_sub(
+            _a_sum_, _b_sum_, _absum_) ;
+
+    /*----------------------------------- return signed d */
+        return _absum_[_absum_._xlen - 1] ;
+    }
+
+    __normal_call REAL_TYPE bisect2w_f (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc ,
+        REAL_TYPE &_FT
+        )
+    {
+    /*--------------- bisect2w predicate, "float" version */
+        REAL_TYPE static const _ER =
+        +  6. * std::pow(mp::_epsilon, 1) ;
+
+        REAL_TYPE _acx, _acy ;
+        REAL_TYPE _bcx, _bcy ;
+        REAL_TYPE _acsqr, _bcsqr ;
+        REAL_TYPE _a_sum, _b_sum ;
+
+        REAL_TYPE _A_SUM, _B_SUM ;
+
+        _acx = _pa [0] - _pc [0] ;        // coord. diff.
+        _acy = _pa [1] - _pc [1] ;
+
+        _bcx = _pb [0] - _pc [0] ;
+        _bcy = _pb [1] - _pc [1] ;
+
+        _acsqr = _acx * _acx +
+                 _acy * _acy ;
+        _bcsqr = _bcx * _bcx +
+                 _bcy * _bcy ;
+
+        _a_sum = _acsqr - _pa[2] ;
+        _b_sum = _bcsqr - _pb[2] ;
+
+        _A_SUM = std::abs(_acsqr)
+               + std::abs(_pa[2]);
+        _B_SUM = std::abs(_bcsqr)
+               + std::abs(_pb[2]);
+
+        _FT  = _A_SUM + _B_SUM ;          // roundoff tol
+        _FT *= _ER ;
+
+        return _a_sum - _b_sum ;          // d_ab - d_bc
+    }
+
+    /*
+    --------------------------------------------------------
+     *
+     * Compute an exact orientation wrt. bisector using 
+     * multi-precision expansions, a'la shewchuk
+     *
+     *   |c-a|**2 - wa = |c-b|**2 - wb
+     *
+     * This is the unweighted "bisect" predicate in E^3.
+     *
+    --------------------------------------------------------
+     */
+
+    __normal_call REAL_TYPE bisect3d_e (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc ,
+        REAL_TYPE &_FT
+        )
+    {
+    /*--------------- bisect3d predicate, "exact" version */
+        mp::expansion< 2 > _ac_xx_, _ac_yy_, 
+                           _ac_zz_,
+                           _bc_xx_, _bc_yy_,
+                           _bc_zz_;
+        mp::expansion< 24> _ac_sq_, _bc_sq_;
+        mp::expansion< 48> _absum_;
+        
+        _FT = (REAL_TYPE) +0.0E+00;
+
+    /*----------------------------------- compute: d(p,q) */
+        _ac_xx_.from_sub(_pc[0], _pa[0]);
+        _ac_yy_.from_sub(_pc[1], _pa[1]);
+        _ac_zz_.from_sub(_pc[2], _pa[2]);
+
+        _bc_xx_.from_sub(_pc[0], _pb[0]);
+        _bc_yy_.from_sub(_pc[1], _pb[1]);
+        _bc_zz_.from_sub(_pc[2], _pb[2]);
+    
+        mp::expansion_dot(_ac_xx_, _ac_xx_,
+                          _ac_yy_, _ac_yy_,
+                          _ac_zz_, _ac_zz_,
+                          _ac_sq_) ;
+
+        mp::expansion_dot(_bc_xx_, _bc_xx_,
+                          _bc_yy_, _bc_yy_,
+                          _bc_zz_, _bc_zz_,
+                          _bc_sq_) ;
+
+    /*----------------------------------- d(a,c) - d(b,c) */
+        mp::expansion_sub(
+            _ac_sq_, _bc_sq_, _absum_) ;
+
+    /*----------------------------------- return signed d */
+        return _absum_[_absum_._xlen - 1] ;
+    }
+
+    __normal_call REAL_TYPE bisect3d_f (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc ,
+        REAL_TYPE &_FT
+        )
+    {
+    /*--------------- bisect3d predicate, "float" version */
+        REAL_TYPE static const _ER =
+        +  6. * std::pow(mp::_epsilon, 1) ;
+
+        REAL_TYPE _acx, _acy, _acz ;
+        REAL_TYPE _bcx, _bcy, _bcz ;
+        REAL_TYPE _acsqr, _bcsqr ;
+
+        REAL_TYPE _ACSQR, _BCSQR ;
+
+        _acx = _pa [0] - _pc [0] ;        // coord. diff.
+        _acy = _pa [1] - _pc [1] ;
+        _acz = _pa [2] - _pc [2] ;
+
+        _bcx = _pb [0] - _pc [0] ;
+        _bcy = _pb [1] - _pc [1] ;
+        _bcz = _pb [2] - _pc [2] ;
+
+        _acsqr = _acx * _acx +
+                 _acy * _acy +
+                 _acz * _acz ;
+        _bcsqr = _bcx * _bcx +
+                 _bcy * _bcy +
+                 _bcz * _bcz ;
+
+        _ACSQR = std::abs(_acsqr);
+        _BCSQR = std::abs(_bcsqr);
+
+        _FT  = _ACSQR + _BCSQR ;          // roundoff tol
+        _FT *= _ER ;
+
+        return _acsqr - _bcsqr ;          // d_ab - d_bc
+    }
+
+    /*
+    --------------------------------------------------------
+     *
+     * Compute an exact orientation wrt. bisector using 
+     * multi-precision expansions, a'la shewchuk
+     *
+     *   |c-a|**2 - wa = |c-b|**2 - wb
+     *
+     * This is the weighted "bisect" predicate in E^3.
+     *
+    --------------------------------------------------------
+     */
+
+    __normal_call REAL_TYPE bisect3w_e (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc ,
+        REAL_TYPE &_FT
+        )
+    {
+    /*--------------- bisect3w predicate, "exact" version */
+        mp::expansion< 2 > _ac_xx_, _ac_yy_, 
+                           _ac_zz_,
+                           _bc_xx_, _bc_yy_,
+                           _bc_zz_;
+        mp::expansion< 24> _ac_sq_, _bc_sq_;
+        mp::expansion< 25> _a_sum_, _b_sum_;
+        mp::expansion< 50> _absum_;
+        
+        _FT = (REAL_TYPE) +0.0E+00;
+
+        mp::expansion< 1 > _pa_ww_(_pa[ 3]);
+        mp::expansion< 1 > _pb_ww_(_pb[ 3]);
+
+    /*----------------------------------- compute: d(p,q) */
+        _ac_xx_.from_sub(_pc[0], _pa[0]);
+        _ac_yy_.from_sub(_pc[1], _pa[1]);
+        _ac_zz_.from_sub(_pc[2], _pa[2]);
+
+        _bc_xx_.from_sub(_pc[0], _pb[0]);
+        _bc_yy_.from_sub(_pc[1], _pb[1]);
+        _bc_zz_.from_sub(_pc[2], _pb[2]);
+    
+        mp::expansion_dot(_ac_xx_, _ac_xx_,
+                          _ac_yy_, _ac_yy_,
+                          _ac_zz_, _ac_zz_,
+                          _ac_sq_) ;
+
+        mp::expansion_dot(_bc_xx_, _bc_xx_,
+                          _bc_yy_, _bc_yy_,
+                          _bc_zz_, _bc_zz_,
+                          _bc_sq_) ;
+
+        mp::expansion_sub(
+            _ac_sq_, _pa_ww_, _a_sum_) ;
+
+        mp::expansion_sub(
+            _bc_sq_, _pb_ww_, _b_sum_) ;
+
+    /*----------------------------------- d(a,c) - d(b,c) */
+        mp::expansion_sub(
+            _a_sum_, _b_sum_, _absum_) ;
+
+    /*----------------------------------- return signed d */
+        return _absum_[_absum_._xlen - 1] ;
+    }
+
+    __normal_call REAL_TYPE bisect3w_f (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc ,
+        REAL_TYPE &_FT
+        )
+    {
+    /*--------------- bisect3w predicate, "float" version */
+        REAL_TYPE static const _ER =
+        +  7. * std::pow(mp::_epsilon, 1) ;
+
+        REAL_TYPE _acx, _acy, _acz ;
+        REAL_TYPE _bcx, _bcy, _bcz ;
+        REAL_TYPE _acsqr, _bcsqr ;
+        REAL_TYPE _a_sum, _b_sum ;
+
+        REAL_TYPE _A_SUM, _B_SUM ;
+
+        _acx = _pa [0] - _pc [0] ;        // coord. diff.
+        _acy = _pa [1] - _pc [1] ;
+        _acz = _pa [2] - _pc [2] ;
+
+        _bcx = _pb [0] - _pc [0] ;
+        _bcy = _pb [1] - _pc [1] ;
+        _bcz = _pb [2] - _pc [2] ;
+
+        _acsqr = _acx * _acx +
+                 _acy * _acy +
+                 _acz * _acz ;
+        _bcsqr = _bcx * _bcx +
+                 _bcy * _bcy +
+                 _bcz * _bcz ;
+
+        _a_sum = _acsqr - _pa[3] ;
+        _b_sum = _bcsqr - _pb[3] ;
+
+        _A_SUM = std::abs(_acsqr)
+               + std::abs(_pa[3]);
+        _B_SUM = std::abs(_bcsqr)
+               + std::abs(_pb[3]);
+
+        _FT  = _A_SUM + _B_SUM ;          // roundoff tol
+        _FT *= _ER ;
+
+        return _a_sum - _b_sum ;          // d_ab - d_bc
+    }
+
+
+

--- a/predicate/inball_k.hpp
+++ b/predicate/inball_k.hpp
@@ -31,7 +31,7 @@
      *
     --------------------------------------------------------
      *
-     * Last updated: 01 March, 2020
+     * Last updated: 08 April, 2020
      *
      * Copyright 2020--
      * Darren Engwirda
@@ -165,8 +165,7 @@
     {
     /*--------------- inball2d predicate, "float" version */
         REAL_TYPE static const _ER =
-        + 10. * std::pow(mp::_epsilon, 1) +
-        + 96. * std::pow(mp::_epsilon, 2) ;
+        + 11. * std::pow(mp::_epsilon, 1) ;
 
         REAL_TYPE _adx, _ady, _ali ,
                   _bdx, _bdy, _bli ,
@@ -351,8 +350,7 @@
     {
     /*--------------- inball2w predicate, "float" version */
         REAL_TYPE static const _ER =
-        + 10. * std::pow(mp::_epsilon, 1) +
-        + 96. * std::pow(mp::_epsilon, 2) ;
+        + 12. * std::pow(mp::_epsilon, 1) ;
 
         REAL_TYPE _adx, _ady, _adw ,
                   _bdx, _bdy, _bdw ,
@@ -643,8 +641,7 @@
     {
     /*--------------- inball3d predicate, "float" version */
         REAL_TYPE static const _ER =
-        + 16. * std::pow(mp::_epsilon, 1) +
-        +224. * std::pow(mp::_epsilon, 2) ;
+        + 17. * std::pow(mp::_epsilon, 1) ;
 
         REAL_TYPE _aex, _aey, _aez ,
                   _ali,
@@ -1031,8 +1028,7 @@
     {
     /*--------------- inball3w predicate, "float" version */
         REAL_TYPE static const _ER =
-        + 16. * std::pow(mp::_epsilon, 1) +
-        +224. * std::pow(mp::_epsilon, 2) ;
+        + 18. * std::pow(mp::_epsilon, 1) ;
 
         REAL_TYPE _aex, _aey, _aez ,
                   _aew, _ali,

--- a/predicate/orient_k.hpp
+++ b/predicate/orient_k.hpp
@@ -31,7 +31,7 @@
      *
     --------------------------------------------------------
      *
-     * Last updated: 01 March, 2020
+     * Last updated: 08 April, 2020
      *
      * Copyright 2020--
      * Darren Engwirda
@@ -104,8 +104,7 @@
     {
     /*--------------- orient2d predicate, "float" version */
         REAL_TYPE static const _ER =
-        +  3. * std::pow(mp::_epsilon, 1) +
-        + 16. * std::pow(mp::_epsilon, 2) ;
+        +  4. * std::pow(mp::_epsilon, 1) ;
 
         REAL_TYPE _acx, _acy ;
         REAL_TYPE _bcx, _bcy ;
@@ -234,8 +233,7 @@
     {
     /*--------------- orient3d predicate, "float" version */
         REAL_TYPE static const _ER =
-        +  7. * std::pow(mp::_epsilon, 1) +
-        + 56. * std::pow(mp::_epsilon, 2) ;
+        +  8. * std::pow(mp::_epsilon, 1) ;
 
         REAL_TYPE _adx, _ady, _adz ,
                   _bdx, _bdy, _bdz ,

--- a/predicate/predicate_k.hpp
+++ b/predicate/predicate_k.hpp
@@ -16,6 +16,17 @@
      * Point Arithmetic & Fast Robust Geometric Predicates
      * Discrete & Computational Geometry, 18, pp. 305-363.
      *
+     * A translational version of BFS semi-static filtering
+     * is employed, adapted from, e.g.
+     *
+     * C. Burnikel, S. Funke, and M. Seel (2001), Exact 
+     * geometric computation using cascading.
+     * IJCGA (Special issue) 11 (3), pp. 245–266.
+     *
+     * O. Devillers and S. Pion (2002), Efficient Exact 
+     * Geometric Predicates for Delaunay Triangulations.
+     * RR-4351, INRIA. inria-00072237
+     *
     --------------------------------------------------------
      *
      * This program may be freely redistributed under the
@@ -45,7 +56,7 @@
      *
     --------------------------------------------------------
      *
-     * Last updated: 01 March, 2020
+     * Last updated: 09 April, 2020
      *
      * Copyright 2020--
      * Darren Engwirda
@@ -68,7 +79,7 @@
     namespace mp=mp_float;
 
 #   include "orient_k.hpp"
-//  include "bisect_k.hpp"
+#   include "bisect_k.hpp"
 //  include "linear_k.hpp"
 #   include "inball_k.hpp"
 
@@ -86,6 +97,7 @@
             ) ;
 
         if (_rr > _FT || _rr < -_FT)
+            if (std::isnormal(_rr))
             return _rr ;
 
         _rr = orient2d_e(               // "exact" kernel
@@ -113,6 +125,7 @@
             ) ;
 
         if (_rr > _FT || _rr < -_FT)
+            if (std::isnormal(_rr))
             return _rr ;
 
         _rr = orient3d_e(               // "exact" kernel
@@ -123,6 +136,128 @@
             return _rr ;
 
         return (REAL_TYPE) +0.0E+00;
+    }
+
+    __inline_call REAL_TYPE bisect2d (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc        
+        )
+    {
+    /*------------ bisect2d predicate, "filtered" version */
+        REAL_TYPE _FT, _rr;
+
+        _rr = bisect2d_f(               // "float" kernel
+            _pa, _pb, _pc, _FT
+            ) ;
+
+        if (_rr > _FT || _rr < -_FT)
+            if (std::isnormal(_rr))
+            return _rr ;
+        
+        _rr = bisect2d_e(               // "exact" kernel
+            _pa, _pb, _pc, _FT
+            ) ;
+        
+        if (_rr > _FT || _rr < -_FT)
+            return _rr ;
+
+        return (REAL_TYPE) +0.0E+00;
+    }
+
+    __inline_call REAL_TYPE bisect2w (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc        
+        )
+    {
+    /*------------ bisect2w predicate, "filtered" version */
+        if (_pa [ 2] == _pb [ 2] )
+        {                   // equal weights, do bisect2d
+        return bisect2d(_pa, _pb, _pc) ;
+        }
+        else
+        {
+        REAL_TYPE _FT, _rr; // given weights, full kernel
+
+        _rr = bisect2w_f(               // "float" kernel
+            _pa, _pb, _pc, _FT
+            ) ;
+
+        if (_rr > _FT || _rr < -_FT)
+            if (std::isnormal(_rr))
+            return _rr ;
+        
+        _rr = bisect2w_e(               // "exact" kernel
+            _pa, _pb, _pc, _FT
+            ) ;
+
+        if (_rr > _FT || _rr < -_FT)
+            return _rr ;
+
+        return (REAL_TYPE) +0.0E+00;
+        }
+    }
+
+    __inline_call REAL_TYPE bisect3d (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc    
+        )
+    {
+    /*------------ bisect3d predicate, "filtered" version */
+        REAL_TYPE _FT, _rr;
+
+        _rr = bisect3d_f(               // "float" kernel
+            _pa, _pb, _pc, _FT
+            ) ;
+
+        if (_rr > _FT || _rr < -_FT)
+            if (std::isnormal(_rr))
+            return _rr ;
+        
+        _rr = bisect3d_e(               // "exact" kernel
+            _pa, _pb, _pc, _FT
+            ) ;
+
+        if (_rr > _FT || _rr < -_FT)
+            return _rr ;
+
+        return (REAL_TYPE) +0.0E+00;
+    }
+
+    __inline_call REAL_TYPE bisect3w (
+      __const_ptr(REAL_TYPE) _pa ,
+      __const_ptr(REAL_TYPE) _pb ,
+      __const_ptr(REAL_TYPE) _pc
+        )
+    {
+    /*------------ bisect2w predicate, "filtered" version */
+        if (_pa [ 3] == _pb [ 3] )
+        {                   // equal weights, do bisect3d
+        return bisect3d(_pa, _pb, _pc) ;
+        }
+        else
+        {
+        REAL_TYPE _FT, _rr; // given weights, full kernel
+
+        _rr = bisect3w_f(               // "float" kernel
+            _pa, _pb, _pc, _FT
+            ) ;
+
+        if (_rr > _FT || _rr < -_FT)
+            if (std::isnormal(_rr))
+            return _rr ;
+        
+        _rr = bisect3w_e(               // "exact" kernel
+            _pa, _pb, _pc, _FT
+            ) ;
+
+        if (_rr > _FT || _rr < -_FT)
+            return _rr ;
+
+        return (REAL_TYPE) +0.0E+00;
+        }
     }
 
     __inline_call REAL_TYPE inball2d (
@@ -140,6 +275,7 @@
             ) ;
 
         if (_rr > _FT || _rr < -_FT)
+            if (std::isnormal(_rr))
             return _rr ;
 
         _rr = inball2d_e(               // "exact" kernel
@@ -177,6 +313,7 @@
             ) ;
 
         if (_rr > _FT || _rr < -_FT)
+            if (std::isnormal(_rr))
             return _rr ;
 
         _rr = inball2w_e(               // "exact" kernel
@@ -206,6 +343,7 @@
             ) ;
 
         if (_rr > _FT || _rr < -_FT)
+            if (std::isnormal(_rr))
             return _rr ;
 
         _rr = inball3d_e(               // "exact" kernel
@@ -245,6 +383,7 @@
             ) ;
 
         if (_rr > _FT || _rr < -_FT)
+            if (std::isnormal(_rr))
             return _rr ;
 
         _rr = inball3w_e(               // "exact" kernel


### PR DESCRIPTION
- New `bisect(a,b,c)` predicates, to compute orientation of `c` wrt. (weighted) bisector of `(a,b)`.
- Clean up filter implementation throughout, adopt semi-static `BFS`-type approach.